### PR TITLE
bump to resolve security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "async": "^0.9.0",
     "mime": "^1.3.4",
     "progress-stream": "^2.0.0",
-    "request": "^2.55.0",
+    "request": "^2.85.0",
     "util-extend": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
https://nodesecurity.io/advisories/566

same as: https://github.com/hypermodules/gh-release/pull/72

i don't have push access to this repo though.