### PR TITLE
maint: lint, replace unmaintained devDep (tap-spec)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,29 @@
-var extend = require('util-extend')
-var get = require('simple-get')
-var async = require('async')
-var mime = require('mime')
-var progress = require('progress-stream')
-var fs = require('fs')
-var path = require('path')
-var Emitter = require('events').EventEmitter
-var pkg = require('./package.json')
-var pumpify = require('pumpify')
+const extend = require('util-extend')
+const get = require('simple-get')
+const async = require('async')
+const mime = require('mime')
+const progress = require('progress-stream')
+const fs = require('fs')
+const path = require('path')
+const Emitter = require('events').EventEmitter
+const pkg = require('./package.json')
+const pumpify = require('pumpify')
 
 function Upload () {
-  var self = this
-  var opts = this.opts
-  var cb = this.cb
+  const self = this
+  const opts = this.opts
+  const cb = this.cb
 
   if (!opts.assets || opts.assets.length === 0) return cb(new Error('Must specify at least one asset to upload'))
   if (!opts.token && !opts.auth) return cb(new Error('You must define either a token or username/password'))
-  var files = []
+  const files = []
 
   async.eachSeries(opts.assets, function (asset, callback) {
-    var fileName = asset.name || path.basename(asset)
+    const fileName = asset.name || path.basename(asset)
     asset = asset.path || asset
-    var uploadUri = opts.url.split('{')[0] + '?name=' + fileName
+    const uploadUri = opts.url.split('{')[0] + '?name=' + fileName
 
-    var stat
+    let stat
 
     try {
       stat = fs.statSync(asset)
@@ -33,14 +33,14 @@ function Upload () {
 
     self.emit('upload-asset', fileName)
 
-    var rd = fs.createReadStream(asset)
+    const rd = fs.createReadStream(asset)
 
-    var progressOpts = { length: stat.size, time: 100 }
-    var prog = progress(progressOpts, function (p) {
+    const progressOpts = { length: stat.size, time: 100 }
+    const prog = progress(progressOpts, function (p) {
       self.emit('upload-progress', fileName, p)
     })
 
-    var form = {
+    const form = {
       method: 'POST',
       url: uploadUri,
       headers: {
@@ -71,8 +71,8 @@ function Upload () {
 }
 
 function UploadAsset (opts, cb) {
-  var Uploader = extend(new Emitter(), { upload: Upload })
-  var uploader = Object.create(Uploader)
+  const Uploader = extend(new Emitter(), { upload: Upload })
+  const uploader = Object.create(Uploader)
   uploader.opts = opts || {}
   uploader.cb = cb || function noop () {}
   uploader.upload()

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {
     "gh-release": "^6.0.0",
     "standard": "^16.0.2",
-    "tape": "^5.0.0",
-    "tap-spec": "^5.0.0"
+    "tap-arc": "^0.3.4",
+    "tape": "^5.0.0"
   },
   "files": [
     "index.js"
@@ -43,6 +43,6 @@
   },
   "scripts": {
     "release": "gh-release --owner=ungoldman && npm publish",
-    "test": "standard && tape test/index.js | tap-spec"
+    "test": "standard && tape test/index.js | tap-arc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "bugs": {
     "url": "https://github.com/ungoldman/gh-release-assets/issues"
   },
+  "contributors": [
+    "Nate Goldman <ungoldman@gmail.com>",
+    "Bret Comnes <bcomnes@gmail.com>",
+    "Paul C Pederson <paul.c.pederson@gmail.com>"
+  ],
   "dependencies": {
     "async": "^3.2.0",
     "mime": "^2.4.6",

--- a/test/index.js
+++ b/test/index.js
@@ -1,15 +1,15 @@
-var ghReleaseAssets = require('../')
-var format = require('util').format
-var path = require('path')
-var test = require('tape')
-var fixture = path.join.bind(null, __dirname, 'fixtures')
+const ghReleaseAssets = require('../')
+const format = require('util').format
+const path = require('path')
+const test = require('tape')
+const fixture = path.join.bind(null, __dirname, 'fixtures')
 
-var TOKEN = process.env.TOKEN
-var REPO = process.env.REPO || 'ungoldman/gh-release-test'
-var RELEASE = process.env.RELEASE
+const TOKEN = process.env.TOKEN
+const REPO = process.env.REPO || 'ungoldman/gh-release-test'
+const RELEASE = process.env.RELEASE
 
 function auth (assets) {
-  var options = {
+  const options = {
     url: format('https://uploads.github.com/repos/%s/releases/%s/assets{?name}', REPO, RELEASE),
     token: TOKEN,
     assets: assets
@@ -18,7 +18,7 @@ function auth (assets) {
 }
 
 test('should return an error if no assets passed', function (t) {
-  var assets = []
+  const assets = []
   ghReleaseAssets(auth(assets), function (err, assets) {
     t.ok(err)
     t.end()
@@ -26,7 +26,7 @@ test('should return an error if no assets passed', function (t) {
 })
 
 test('should return an error for missing files', function (t) {
-  var assets = ['non-existent-bananas.txt']
+  const assets = ['non-existent-bananas.txt']
   ghReleaseAssets(auth(assets), function (err, assets) {
     t.ok(err)
     t.end()
@@ -34,7 +34,7 @@ test('should return an error for missing files', function (t) {
 })
 
 test('should return an error if there is no token or auth', function (t) {
-  var options = {
+  const options = {
     url: 'https://uploads.github.com/repos/bcomnes/gh-release-test/releases/1039654/assets{?name}',
     assets: [fixture('bananas.txt')]
   }
@@ -45,7 +45,7 @@ test('should return an error if there is no token or auth', function (t) {
 })
 
 test('should upload an asset in string format', function (t) {
-  var assets = [fixture('bananas.zip')]
+  const assets = [fixture('bananas.zip')]
   ghReleaseAssets(auth(assets), function (err, files) {
     t.error(err)
     t.equal(files[0], 'bananas.zip')
@@ -54,8 +54,8 @@ test('should upload an asset in string format', function (t) {
 })
 
 test('should upload an answer in object format', function (t) {
-  var fileName = Date.now() + '.txt'
-  var assets = [{
+  const fileName = Date.now() + '.txt'
+  const assets = [{
     name: fileName,
     path: fixture('bananas.txt')
   }]
@@ -67,8 +67,8 @@ test('should upload an answer in object format', function (t) {
 })
 
 test('should emit `upload-asset` event', function (t) {
-  var assets = [fixture('bananas.txt')]
-  var release = ghReleaseAssets(auth(assets), function (err) {
+  const assets = [fixture('bananas.txt')]
+  const release = ghReleaseAssets(auth(assets), function (err) {
     t.error(err)
     t.end()
   })
@@ -79,8 +79,8 @@ test('should emit `upload-asset` event', function (t) {
 
 test('should emit `upload-progress` events', function (t) {
   t.plan(2)
-  var assets = [fixture('bananas.txt')]
-  var release = ghReleaseAssets(auth(assets))
+  const assets = [fixture('bananas.txt')]
+  const release = ghReleaseAssets(auth(assets))
   release.on('upload-progress', function (fileName, progress) {
     t.equal(fileName, 'bananas.txt')
     t.ok(progress)
@@ -89,8 +89,8 @@ test('should emit `upload-progress` events', function (t) {
 
 test('should emit `uploaded-asset` event', function (t) {
   t.plan(1)
-  var assets = [fixture('bananas.txt')]
-  var release = ghReleaseAssets(auth(assets))
+  const assets = [fixture('bananas.txt')]
+  const release = ghReleaseAssets(auth(assets))
   release.on('uploaded-asset', function (fileName) {
     t.equal(fileName, 'bananas.txt')
   })


### PR DESCRIPTION
- replaces `tap-spec` (unmaintained, security warnings) with [`tap-arc`](https://www.npmjs.com/package/tap-arc)
- auto-fixes for linting errors
- add contributors section to package.json

Sidenote: The tests weren't passing when I ran locally, but ci seemed to indicate things were fine. I did some digging and it looks like there were a bunch of standard warnings but the test suite still came back green, which is weird/concerning. Example:


![Screen Shot 2022-04-14 at 1 33 31 PM](https://user-images.githubusercontent.com/427322/163470943-860c6ab9-19e0-4c01-b29b-aaf978045aad.png)

From last job: https://github.com/ungoldman/gh-release-assets/runs/5561851927?check_suite_focus=true

Tests look okay for this one but I'm still a little concerned that there are false positives here or elsewhere, since I'm using the same config for github actions in most of my repos now.