### PR TITLE
pkg(engines): node >= 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "tap-arc": "^0.3.4",
     "tape": "^5.0.0"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
- add engines field to package.json, setting node to `>=12`

@bcomnes tagging you for this one since you mentioned it in https://github.com/ungoldman/gh-release-assets/pull/13#pullrequestreview-801458150

I think it's reasonable to just go with a minimum major version.

Resolves #14 