### PR TITLE
chore: sync package-lock.json with the bin field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "mime": "^4.1.0"
       },
+      "bin": {
+        "gh-release-assets": "dist/cli.js"
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.5.0",
         "@types/node": "^22.19.21",


### PR DESCRIPTION
The CLI `bin` entry was added to `package.json` during the TypeScript conversion (#23) but the lockfile was never regenerated, so its root-package entry was missing the `bin` block. This surfaced after the 3.0.0 release: a fresh clone + `npm install` shows the lockfile updating to add it.

No dependency-tree or version changes, just the missing metadata. The published 3.0.0 tarball already carries `bin` in its `package.json`, so the CLI installs fine; this only fixes the stale lockfile committed to the repo.

```
+      "bin": {
+        "gh-release-assets": "dist/cli.js"
+      },
```