### PR TITLE
docs: size readme logo and add alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="./logo.png">
+<img src="./logo.png" width="120" height="120" alt="paperclip">
 
 # gh-release-assets
 


### PR DESCRIPTION
Display the README logo at 120×120 with alt text, matching the gh-release logo pattern.