### PR TITLE
docs: add agent guidelines and coding conventions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Guidelines
+
+- install: `npm install`
+- test: `npm test`
+- coverage: `npm run coverage`
+
+Release automated by `.github/workflows/release.yml`, do not alter version.
+
+Follow all coding and commit conventions in `CONTRIBUTING.md`.
+
+Omit AI attribution in commits (Co-authored-by). Polluting git history with AI advertising is not allowed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,12 @@ Fork & clone the repo, then `npm install` to install all dependencies.
 Run `npm test`. This lints with [Biome](https://biomejs.dev/), type-checks and builds with [TypeScript](https://www.typescriptlang.org/), and runs the [`node:test`](https://nodejs.org/api/test.html) suite. The tests run against a local HTTP server fixture, so no GitHub token or network access is required.
 
 Run `npm run coverage` to check coverage (held at 100%), and `npm run format` to apply lint and formatting fixes.
+
+# Coding Guidelines
+
+- Commits should be atomic and adhere to [conventional commit](https://conventionalcommits.org) standards.
+- Commit messages should be short (`<topic>: <action>`, 50 char max), and commit bodies only included when necessary for complex changes (72 char max).
+- Breaking changes are discouraged, and require a `BREAKING CHANGE:` footer in the commit body explaining the change.
+- Types and interfaces should be inlined unless they're absolutely necessary for exporting or testing.
+- Avoid unnecessary code comments, and keep necessary ones trim.
+- All changes should maintain the test coverage gate (100%).


### PR DESCRIPTION
Adds the agent-facing docs and coding guidelines that were missing here: CONTRIBUTING.md now states the commit conventions and the coverage gate, and AGENTS.md (with CLAUDE.md symlinked to it) gives agents the ground rules, including the do-not-alter-version warning the release automation depends on.

## Changes
- CONTRIBUTING.md: add Coding Guidelines (conventional commits, breaking-change policy, coverage gate)
- add AGENTS.md; symlink CLAUDE.md to it
- tests.yml: cancel superseded runs on the same ref